### PR TITLE
fix download-artifact v1->v2 compatibility

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -54,15 +54,15 @@ jobs:
       - uses: actions/download-artifact@v2.1.0
         with:
           name: main-ubuntu-latest
+          path: main-ubuntu-latest
       - uses: actions/download-artifact@v2.1.0
         with:
           name: main-macos-latest
+          path: main-macos-latest
       - uses: actions/download-artifact@v2.1.0
         with:
           name: main-windows-latest
-      - uses: actions/download-artifact@v2.1.0
-        with:
-          name: main-windows-latest
+          path: main-windows-latest
       - run: |
          mkdir -p dist
          mv main-windows-latest/main dist/main_windows.exe


### PR DESCRIPTION

<details>
<summary>
Committer details
</summary>
Local-Branch: master
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
bump go to 1.17 (#15)
</summary>

</details>
<details>
<summary>
bump toolkit version (#16)
</summary>

</details>
</details>
</details>